### PR TITLE
Update plan-and-execute example to Korean translation

### DIFF
--- a/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb
+++ b/docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb
@@ -288,12 +288,12 @@
     }
    ],
    "source": [
-    "planner.invoke(\n",
-    "    {\n",
-    "        \"messages\": [\n",
-    "            (\"user\", \"what is the hometown of the current Australia open winner?\")\n",
-    "        ]\n",
-    "    }\n",
+    "planner.invoke(",
+    "    {",
+    "        \"messages\": [",
+    "            (\"user\", \"Translate \"I love programming with LangGraph\" into Korean\")",
+    "        ]",
+    "    }",
     ")"
    ]
   },
@@ -493,11 +493,13 @@
     }
    ],
    "source": [
-    "config = {\"recursion_limit\": 50}\n",
-    "inputs = {\"input\": \"what is the hometown of the mens 2024 Australia open winner?\"}\n",
-    "async for event in app.astream(inputs, config=config):\n",
-    "    for k, v in event.items():\n",
-    "        if k != \"__end__\":\n",
+    "config = {\"recursion_limit\": 50}",
+    "",
+    "inputs = {\"input\": \"Translate \"I love programming with LangGraph\" into Korean\"}",
+    "",
+    "async for event in app.astream(inputs, config=config):",
+    "    for k, v in event.items():",
+    "        if k != \"__end__\":",
     "            print(v)"
    ]
   },


### PR DESCRIPTION
## Summary
- update plan-and-execute tutorial example to translate an English sentence into Korean

## Testing
- `jq '.' docs/docs/tutorials/plan-and-execute/plan-and-execute.ipynb > /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_688473f8574883288477cbb7b674d411